### PR TITLE
Support/wagtail 64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: 3.9
 
       - name: Install dependencies
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,12 @@
 Changelog
 =========
 
-4.0.1 (02.01.2025)
+Unreleased
+----------
+
+* Update testing environment for Wagtail 6.4
+
+4.0.2 (02.01.2025)
 ----------
 
 * Update the testing environment to test Wagtail 6.3 and Django 5.1

--- a/README.rst
+++ b/README.rst
@@ -33,8 +33,7 @@ The current version is tested for compatibility with the following:
 
 - Wagtail versions >= 5.2
 - Django versions 4.2, 5.0 and >= 5.1
-- Python versions 3.9 to 3.12
-  - Python 3.13 for Django 5.1 with Wagtail releases >= 6.3
+- Python versions 3.9 to 3.13
 
 .. image:: https://raw.githubusercontent.com/jazzband/wagtailmenus/master/docs/source/_static/images/repeating-item.png
 

--- a/README.rst
+++ b/README.rst
@@ -34,6 +34,7 @@ The current version is tested for compatibility with the following:
 - Wagtail versions >= 5.2
 - Django versions 4.2, 5.0 and >= 5.1
 - Python versions 3.9 to 3.12
+  - Python 3.13 for Django 5.1 with Wagtail releases >= 6.3
 
 .. image:: https://raw.githubusercontent.com/jazzband/wagtailmenus/master/docs/source/_static/images/repeating-item.png
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -9,8 +9,7 @@ The current version is tested for compatibility with the following:
 
 - Wagtail versions >= 5.2
 - Django versions 4.2 and >= 5.0
-- Python versions 3.9 to 3.12
-  - Python 3.13 for Django 5.1 with Wagtail releases >= 6.3
+- Python versions 3.9 to 3.13
 
 To find out more about what wagtailmenus does and why, see :doc:`overview`
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -8,8 +8,9 @@ wagtailmenus is an open-source extension for `Wagtail CMS
 The current version is tested for compatibility with the following:
 
 - Wagtail versions >= 5.2
-- Django versions 3.2, 4.2 and >= 5.0
-- Python versions 3.8 to 3.12
+- Django versions 4.2 and >= 5.0
+- Python versions 3.9 to 3.12
+  - Python 3.13 for Django 5.1 with Wagtail releases >= 6.3
 
 To find out more about what wagtailmenus does and why, see :doc:`overview`
 

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,8 @@ envlist =
     wt62-dj{42,50}-py{310,311,312}
     wt63-dj{42,50,51}-py{310,311,312}
     wt63-dj51-py313
+    wt64-dj{42,50,51}-py{310,311,312}
+    wt64-dj51-py313
 
 [gh-actions]
 python =
@@ -36,3 +38,4 @@ deps =
     wt61: wagtail>=6.1,<6.2
     wt62: wagtail>=6.2,<6.3
     wt63: wagtail>=6.3,<6.4
+    wt64: wagtail>=6.4,<6.5


### PR DESCRIPTION
The changes primarily focus on updating the supported versions of Python, Django, and Wagtail, and removing support for older versions and adding some Wagtail version compatibility conditionals.

## Updates to testing environment and compatibility:

[tox.ini](): Updated test matrix for Wagtail 6.4 [[1]]()

## Documentation updates:

[CHANGELOG.md](https://github.com/jazzband/wagtailmenus/pull/503/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR4-R8): Added an entry for the unreleased changes.

